### PR TITLE
Add unpositioned bundle for CSS if never configured in bundles.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "yiisoft/yii2": "*",
         "natxet/cssmin":"3.*",
         "tedivm/jshrink":"1.*",
-        "packagist/yuicompressor-bin":"*",
-        "packagist/closurecompiler-bin":"*"
+        "packagelist/yuicompressor-bin":"*",
+        "packagelist/closurecompiler-bin":"*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Combiner.php
+++ b/src/Combiner.php
@@ -13,7 +13,7 @@ use yii\web\AssetBundle;
  * @author Lajos Molnár <lajax.m@gmail.com>
  * @since 1.0
  */
-class Combiner extends \yii\base\Object
+class Combiner extends \yii\base\BaseObject
 {
 
     /**

--- a/src/Combiner.php
+++ b/src/Combiner.php
@@ -49,12 +49,12 @@ class Combiner extends \yii\base\Object
     /**
      * @var array List of JavaScript és StyleSheet files grouped by positions.
      */
-    private $_files = [];
+    protected $_files = [];
 
     /**
      * @var \yii\web\AssetBundle[] List of AssetBundle objects handling combined files.
      */
-    private $_assetBundles = [];
+    protected $_assetBundles = [];
 
     /**
      * @inheritdoc

--- a/src/Combiner.php
+++ b/src/Combiner.php
@@ -37,6 +37,16 @@ class Combiner extends \yii\base\Object
     public $combinedFilesPath = '/lajax-asset-minifier';
 
     /**
+     * @var string the Web-accessible directory that contains the asset files in this bundle.
+     */
+    public $basePath;
+
+    /**
+     * @var string the base URL for the relative asset files listed in [[js]] and [[css]].
+     */
+    public $baseUrl;
+
+    /**
      * @var array List of JavaScript és StyleSheet files grouped by positions.
      */
     private $_files = [];
@@ -52,8 +62,13 @@ class Combiner extends \yii\base\Object
     public function init()
     {
         parent::init();
-
-        FileHelper::createDirectory(Yii::getAlias('@webroot/assets' . $this->combinedFilesPath), 0777);
+        if(empty($this->basePath)) {
+            $this->basePath = \Yii::$app->assetManager->basePath . '/' . $this->combinedFilesPath;
+        }
+        if(empty($this->baseUrl)) {
+            $this->baseUrl = \Yii::$app->assetManager->baseUrl . '/' . $this->combinedFilesPath;
+        }
+        FileHelper::createDirectory(Yii::getAlias($this->basePath), 0777);
     }
 
     /**
@@ -213,8 +228,8 @@ class Combiner extends \yii\base\Object
     {
         if (!isset($this->_assetBundles[$position])) {
             $config = [
-                'basePath' => Yii::getAlias('@webroot/assets' . $this->combinedFilesPath),
-                'baseUrl' => Yii::getAlias('@web/assets' . $this->combinedFilesPath)
+                'basePath' => Yii::getAlias($this->basePath),
+                'baseUrl' => Yii::getAlias($this->baseUrl)
             ];
 
             if ($position) {
@@ -223,7 +238,6 @@ class Combiner extends \yii\base\Object
 
             $this->_assetBundles[$position] = new AssetBundle($config);
         }
-
         return $this->_assetBundles[$position];
     }
 

--- a/src/Combiner.php
+++ b/src/Combiner.php
@@ -74,7 +74,10 @@ class Combiner extends \yii\base\Object
         foreach (array_keys(Yii::$app->view->assetBundles) as $name) {
             $this->combineAssetBundles($name);
         }
-
+        // If empty position is not created, do it now for CSS
+        if (!isset($this->_assetBundles[''])) {
+            $this->getAssetBundles();
+        }
         $this->saveAssetFiles();
     }
 

--- a/src/Component.php
+++ b/src/Component.php
@@ -23,7 +23,7 @@ use lajax\assetminifier\helpers\AssetMinifier;
  * @author Lajos Molnár <lajax.m@gmail.com>
  * @since 1.0
  */
-class Component extends \yii\base\Object
+class Component extends \yii\base\BaseObject
 {
 
     /**

--- a/src/Minifier.php
+++ b/src/Minifier.php
@@ -13,7 +13,7 @@ use lajax\assetminifier\helpers\AssetMinifier;
  * @author Lajos Molnár <lajax.m@gmail.com>
  * @since 1.0
  */
-class Minifier extends \yii\base\Object
+class Minifier extends \yii\base\BaseObject
 {
 
     /**

--- a/src/minifiers/CliMinifier.php
+++ b/src/minifiers/CliMinifier.php
@@ -8,7 +8,7 @@ namespace lajax\assetminifier\minifiers;
  * @author Lajos Molnár <lajax.m@gmail.com>
  * @since 1.0
  */
-class CliMinifier extends \yii\base\Object implements MinifierInterface
+class CliMinifier extends \yii\base\BaseObject implements MinifierInterface
 {
 
     /**

--- a/src/minifiers/PhpCssMinifier.php
+++ b/src/minifiers/PhpCssMinifier.php
@@ -10,7 +10,7 @@ use CssMin;
  * @author Lajos Molnár <lajax.m@gmail.com>
  * @since 1.0
  */
-class PhpCssMinifier extends \yii\base\Object implements MinifierInterface
+class PhpCssMinifier extends \yii\base\BaseObject implements MinifierInterface
 {
 
     /**

--- a/src/minifiers/PhpJsMinifier.php
+++ b/src/minifiers/PhpJsMinifier.php
@@ -10,7 +10,7 @@ use JShrink\Minifier;
  * @author Lajos Molnár <lajax.m@gmail.com>
  * @since 1.0
  */
-class PhpJsMinifier extends \yii\base\Object implements MinifierInterface
+class PhpJsMinifier extends \yii\base\BaseObject implements MinifierInterface
 {
 
     /**

--- a/src/minifiers/WebMinifier.php
+++ b/src/minifiers/WebMinifier.php
@@ -8,7 +8,7 @@ namespace lajax\assetminifier\minifiers;
  * @author Lajos Molnár <lajax.m@gmail.com>
  * @since 1.0
  */
-class WebMinifier extends \yii\base\Object implements MinifierInterface
+class WebMinifier extends \yii\base\BaseObject implements MinifierInterface
 {
 
     /**


### PR DESCRIPTION
I have noticed that in a configuration where all bundles are "positioned" and none of them is in position '', when minifier register the CSS that is in such position as defined by the framework, a index not found exception is thrown.
My solution is this: to create a empty bundle in key '' if not created before as placeholder for the following CSS assignment.